### PR TITLE
update session.py

### DIFF
--- a/securecrt_tools/sessions.py
+++ b/securecrt_tools/sessions.py
@@ -576,12 +576,14 @@ class CRTSession(Session):
         Discovers Network OS type so that scripts can make decisions based on the information, such as sending a
         different version of a command for a particular OS.
         """
-        send_cmd = "show version | i Cisco"
+        send_cmd = "show version | i Cisco IOS"
 
         raw_version = self.__get_output(send_cmd)
         self.logger.debug("<GET OS> Version String: {0}".format(raw_version))
 
         if "IOS XE" in raw_version:
+            version = "IOS"
+        elif "IOS XR" in raw_version:
             version = "IOS"
         elif "Cisco IOS Software" in raw_version or "Cisco Internetwork Operating System" in raw_version:
             version = "IOS"


### PR DESCRIPTION
Added support to recognize XR, lines 570 added IOS to show version. Certain XR platforms output multiple lines for the keyword Cisco, the output can be hundreds of lines to match on. Example, "iosxr-mcast, V 6.4.1[Default], Cisco Systems, at disk0:iosxr-mcast-6.4.1". Added "IOS" to slim down return string on XR. 
Lines 586-587. Added elif to catch IOS XR and return as IOS OS.